### PR TITLE
Fix footer button alignment

### DIFF
--- a/app.py
+++ b/app.py
@@ -4644,7 +4644,7 @@ def main():
     st.info("🔒 **Privacy Guarantee**: Your documents are NEVER stored on our servers. All files are processed in memory only and immediately deleted after analysis.")
     
     # Legal links in footer
-    spacer_left, col_terms, col_privacy, spacer_right = st.columns([4, 1, 1, 2])
+    spacer_left, col_terms, col_privacy, spacer_right = st.columns([4, 1, 1, 4])
 
     # Inside the centred column, create two equal columns for the buttons
     with col_terms:


### PR DESCRIPTION
## Summary
- center the footer legal buttons so they align with the privacy tagline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c50196f8883249d35b1e3d8fbbfa4