### PR TITLE
Fix credit API dependency error

### DIFF
--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -6,8 +6,8 @@ python-dotenv==1.0.0
 email-validator==2.1.0
 python-multipart==0.0.6
 
-# Environment
-python-dotenv==1.0.0
+# Optional but required when running the full API server
+pandas==2.1.4
 
 # Database (using sqlite3 which is built-in to Python)
 # No SQLAlchemy or other ORMs to avoid dependencies


### PR DESCRIPTION
## Summary
- include `pandas` in `requirements-api.txt` so running the full API server has necessary deps
- clean up trailing whitespace and ensure newline

## Testing
- `python test_credit_api.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687c5249e6c48324a59c45a75e8fc25d