### PR TITLE
Fix footer button styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -4644,7 +4644,7 @@ def main():
     st.info("🔒 **Privacy Guarantee**: Your documents are NEVER stored on our servers. All files are processed in memory only and immediately deleted after analysis.")
     
     # Legal links in footer
-    spacer_left, col_terms, col_privacy, spacer_right = st.columns([4, 1, 1, 2])
+    spacer_left, col_terms, col_privacy, spacer_right = st.columns([4, 1, 1, 4])
 
     # Inside the centred column, create two equal columns for the buttons
     with col_terms:

--- a/style.css
+++ b/style.css
@@ -78,6 +78,23 @@ p, div {
     color: #c9d1d9;
 }
 
+/* Ensure white text for key UI elements */
+.stButton>button,
+.stButton>button div {
+    color: #ffffff !important;
+}
+
+.stCheckbox label,
+.stCheckbox>div,
+.stCheckbox>label {
+    color: #ffffff !important;
+}
+
+.stAlert,
+.stAlert p {
+    color: #ffffff !important;
+}
+
 /* Section labels */
 .section-label {
     font-weight: 500;


### PR DESCRIPTION
## Summary
- ensure legal buttons use white text
- make checkbox labels and info messages white

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c50196f8883249d35b1e3d8fbbfa4