### PR TITLE
Fix credit API dependency error

### DIFF
--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -6,8 +6,9 @@ python-dotenv==1.0.0
 email-validator==2.1.0
 python-multipart==0.0.6
 
-# Environment
-python-dotenv==1.0.0
+# Optional but required when running the full API server
+# Use a version with pre-built wheels for Python 3.13
+pandas==2.2.3
 
 # Database (using sqlite3 which is built-in to Python)
 # No SQLAlchemy or other ORMs to avoid dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 streamlit==1.32.0
-pandas==2.1.4
+pandas==2.2.3
 numpy==1.26.3
 requests==2.31.0
 plotly==5.18.0


### PR DESCRIPTION
## Summary
- include `pandas` >=2.2.3 so credit server installs correctly on Python 3.13

## Testing
- `python test_credit_api.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687c5249e6c48324a59c45a75e8fc25d