### PR TITLE
Fix footer button visibility and label color

### DIFF
--- a/app.py
+++ b/app.py
@@ -1033,7 +1033,7 @@ def inject_custom_css():
     .property-input-container label {
         font-size: 16px;
         font-weight: 500;
-        color: #EAEAEA;
+        color: #FFFFFF;
         margin-bottom: 8px;
     }
     
@@ -1669,6 +1669,19 @@ def inject_custom_css():
         justify-content: center;
         box-sizing: border-box;
         cursor: pointer;
+    }
+
+    /* Bright white labels for inputs and checkboxes */
+    [data-testid="stTextInput"] label,
+    [data-testid="stCheckbox"] label {
+        color: #FFFFFF !important;
+    }
+
+    /* Consistent styling for footer legal buttons */
+    button[aria-label="show_terms"],
+    button[aria-label="show_privacy"] {
+        color: #FFFFFF !important;
+        border: 1px solid #FFFFFF !important;
     }
 
     </style>


### PR DESCRIPTION
## Summary
- update property label style to pure white
- style legal buttons so they display clearly
- ensure checkbox and text input labels use white text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d53943b3c8324a337069e72aa1e2f