### PR TITLE
Ensure white text for discount badges

### DIFF
--- a/style.css
+++ b/style.css
@@ -111,6 +111,13 @@ p, div {
     color: #ffffff !important;
 }
 
+/* Ensure white text for success alerts (discount badges) */
+.stAlert-success,
+.stAlert-success p,
+.stAlert-success span {
+    color: #ffffff !important;
+}
+
 /* Section labels */
 .section-label {
     font-weight: 500;

--- a/utils/credit_ui.py
+++ b/utils/credit_ui.py
@@ -359,6 +359,7 @@ def display_credit_store():
         text-align: center !important;
         font-weight: 700 !important;
         font-size: 0.95rem !important;
+        color: #FFFFFF !important;
         background: linear-gradient(135deg, #22C55E, #16A34A) !important;
         border: 1px solid rgba(34, 197, 94, 0.3) !important;
         box-shadow: 0 2px 8px rgba(34, 197, 94, 0.2) !important;
@@ -466,6 +467,7 @@ def display_credit_store():
         border: 1px solid #305f41 !important;
         box-shadow: none !important;
         opacity: 0.85 !important;
+        color: #FFFFFF !important;
     }
 
     /* Headline style */


### PR DESCRIPTION
## Summary
- ensure success alert text is white in global styles
- force white text color for success badges in credit store UI

## Testing
- `python -m py_compile utils/credit_ui.py`

------
https://chatgpt.com/codex/tasks/task_e_687d8f799bec83289762a627dd01c3f2