### PR TITLE
Fix duplicate credit header

### DIFF
--- a/app.py
+++ b/app.py
@@ -3808,7 +3808,13 @@ def main():
         st.session_state.show_credit_success = False
     
     # Add header credit display for main page (centered)
-    if st.session_state.get('user_email') and CREDIT_SYSTEM_AVAILABLE:
+    if (
+        st.session_state.get('user_email')
+        and CREDIT_SYSTEM_AVAILABLE
+        and not st.session_state.get('processing_completed', False)
+        and not st.session_state.get('template_viewed', False)
+        and not st.session_state.get('consolidated_data')
+    ):
         # Center the credit display
         display_credit_balance_header(st.session_state.user_email)
         


### PR DESCRIPTION
## Summary
- avoid displaying the main page credit header when results or template are visible

## Testing
- `python -m py_compile app.py utils/credit_ui.py`

------
https://chatgpt.com/codex/tasks/task_e_687d903b9e5c8328b2affd3f0ddc4c9a