### PR TITLE
Fix dark text on main UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -741,7 +741,7 @@ def inject_custom_css():
         --reborn-bg-primary: #0A0F1E;
         --reborn-bg-secondary: #10172A;
         --reborn-bg-tertiary: #1E293B;
-        --reborn-text-primary: #F0F0F0;
+        --reborn-text-primary: #FFFFFF;  /* Use pure white for maximum readability */
         --reborn-text-secondary: #A0A0A0;
         --reborn-accent-blue: #3B82F6;
         --reborn-accent-green: #10B981;
@@ -1470,6 +1470,12 @@ def inject_custom_css():
         border-left: none;
     }
 
+    /* Ensure checkbox labels in options container are bright white */
+    .options-container [data-testid="stCheckbox"] label,
+    .options-container [data-testid="stCheckbox"] label * {
+        color: #FFFFFF !important;
+    }
+
     .options-header {
         color: var(--reborn-text-primary);
         font-size: 1.1rem;
@@ -1679,8 +1685,9 @@ def inject_custom_css():
     [data-testid="stSelectbox"] label,
     [data-testid="stMultiselect"] label,
     [data-testid="stSlider"] label,
-    [data-testid="stCheckbox"] label {
-        color: #FFFFFF !important;
+    [data-testid="stCheckbox"] label,
+    [data-testid="stCheckbox"] label * {
+        color: #FFFFFF !important;  /* Ensure checkbox labels are bright white */
     }
     /* Dark text for input values on white backgrounds */
     [data-testid="stTextInput"] input,
@@ -1695,9 +1702,11 @@ def inject_custom_css():
 
 
     /* Consistent styling for footer legal buttons */
-    button[aria-label="show_terms"],
-    button[aria-label="show_privacy"] {
+    /* Style all secondary buttons (used for legal links) */
+    .stButton > button[kind="secondary"],
+    button[data-testid="baseButton-secondary"] {
         color: #FFFFFF !important;
+        background-color: transparent !important;
         border: 1px solid #FFFFFF !important;
     }
 
@@ -4680,7 +4689,7 @@ def main():
     st.info("🔒 **Privacy Guarantee**: Your documents are NEVER stored on our servers. All files are processed in memory only and immediately deleted after analysis.")
     
     # Legal links in footer
-    spacer_left, col_terms, col_privacy, spacer_right = st.columns([4, 1, 1, 4])
+    spacer_left, col_terms, col_privacy, spacer_right = st.columns([3, 2, 2, 3])
 
     # Inside the centred column, create two equal columns for the buttons
     with col_terms:


### PR DESCRIPTION
## Summary
- force custom checkbox label styling to affect all child nodes
- style all secondary buttons, including Terms/Privacy buttons, with bright white text
- expand footer columns so legal buttons fit text
- ensure option labels in the checkbox section remain white

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687d938c5a6883289dec39b8d0a791d6