### PR TITLE
Adjust info alert styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -1308,9 +1308,9 @@ def inject_custom_css():
     
     /* Info, warning, error messages styling */
     .stInfo, .element-container .alert-info {
-        background-color: rgba(56, 189, 248, 0.1) !important;
-        border-left: 4px solid #38BDF8 !important;
-        color: #E0E0E0 !important;
+        background-color: rgba(96, 165, 250, 0.25) !important;
+        border-left: 4px solid #60A5FA !important;
+        color: #FFFFFF !important;
         padding: 1rem !important;
         border-radius: 8px !important;
         margin: 1rem 0 !important;

--- a/style.css
+++ b/style.css
@@ -118,6 +118,13 @@ p, div {
     color: #ffffff !important;
 }
 
+/* Lighter blue background for info alerts */
+.stAlert-info {
+    background-color: rgba(59, 130, 246, 0.2) !important;
+    border: 1px solid rgba(59, 130, 246, 0.4) !important;
+    color: #ffffff !important;
+}
+
 /* Section labels */
 .section-label {
     font-weight: 500;


### PR DESCRIPTION
## Summary
- lighten the info alert background for better legibility by editing injected CSS

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687d935c251c832885e46741b4b27fa8