### PR TITLE
Update process button styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -1533,9 +1533,9 @@ def inject_custom_css():
     
     /* Enhanced Process Documents button */
     .stButton > button[kind="primary"] {
-        background-color: #0E4DE3 !important; /* Dark blue theme color */
-        color: white !important;
-        border: 1px solid #1C5CF5 !important; /* Slightly lighter blue border */
+        background-color: #FFFFFF !important;
+        color: #79b8f3 !important;
+        border: 1px solid #79b8f3 !important;
         font-size: 1.1rem !important;
         font-weight: 500 !important;
         padding: 0.75rem 1.5rem !important;
@@ -1548,8 +1548,9 @@ def inject_custom_css():
     }
     
     .stButton > button[kind="primary"]:hover {
-        background-color: #1C5CF5 !important; /* Hover dark blue */
-        border-color: #0E4DE3 !important;
+        background-color: #f0f6ff !important;
+        border-color: #79b8f3 !important;
+        color: #79b8f3 !important;
         box-shadow: 0 4px 12px rgba(121, 184, 243, 0.4) !important;
         transform: translateY(-2px) !important;
     }
@@ -1559,9 +1560,9 @@ def inject_custom_css():
     div[data-testid="stButton"] > button[data-testid="baseButton-primary"],
     .stApp div[data-testid="stButton"] > button[kind="primary"],
     .stApp div[data-testid="stButton"] > button[data-testid="baseButton-primary"] {
-        background-color: #0E4DE3 !important;
-        color: white !important;
-        border: 1px solid #1C5CF5 !important;
+        background-color: #FFFFFF !important;
+        color: #79b8f3 !important;
+        border: 1px solid #79b8f3 !important;
         font-size: 1.1rem !important;
         font-weight: 500 !important;
         padding: 0.75rem 1.5rem !important;
@@ -1577,17 +1578,18 @@ def inject_custom_css():
     div[data-testid="stButton"] > button[data-testid="baseButton-primary"]:hover,
     .stApp div[data-testid="stButton"] > button[kind="primary"]:hover,
     .stApp div[data-testid="stButton"] > button[data-testid="baseButton-primary"]:hover {
-        background-color: #1C5CF5 !important;
-        border-color: #0E4DE3 !important;
+        background-color: #f0f6ff !important;
+        border-color: #79b8f3 !important;
+        color: #79b8f3 !important;
         box-shadow: 0 4px 12px rgba(121, 184, 243, 0.4) !important;
         transform: translateY(-2px) !important;
     }
 
     /* Target specific button by key if needed */
     button[data-testid="baseButton-primary"][aria-label*="main_process_button"] {
-        background-color: #0E4DE3 !important;
-        color: white !important;
-        border: 1px solid #1C5CF5 !important;
+        background-color: #FFFFFF !important;
+        color: #79b8f3 !important;
+        border: 1px solid #79b8f3 !important;
     }
     /* Hide dark/light theme toggle button */
     .theme-toggle { display: none !important; }
@@ -3978,9 +3980,9 @@ def main():
             /* Enhanced Process Documents button - increased specificity */
             .stApp .stButton > button[kind="primary"],
             .stApp .stButton > button[data-testid="baseButton-primary"] {
-                background-color: #0E4DE3 !important; /* Dark blue theme color */
-                color: white !important;
-                border: 1px solid #1C5CF5 !important; /* Slightly lighter blue border */
+                background-color: #FFFFFF !important;
+                color: #79b8f3 !important;
+                border: 1px solid #79b8f3 !important;
                 font-size: 1.1rem !important;
                 font-weight: 500 !important;
                 padding: 0.75rem 1.5rem !important;
@@ -3991,11 +3993,12 @@ def main():
                 margin-bottom: 1.5rem !important;
                 width: 100% !important;
             }
-            
+
             .stApp .stButton > button[kind="primary"]:hover,
             .stApp .stButton > button[data-testid="baseButton-primary"]:hover {
-                background-color: #1C5CF5 !important; /* Hover dark blue */
-                border-color: #0E4DE3 !important;
+                background-color: #f0f6ff !important;
+                border-color: #79b8f3 !important;
+                color: #79b8f3 !important;
                 box-shadow: 0 4px 12px rgba(121, 184, 243, 0.4) !important;
                 transform: translateY(-2px) !important;
             }


### PR DESCRIPTION
## Summary
- update inline CSS in app to style the Process Documents button with a white background and light blue text

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687e5ce6a1d48328bfe474690a65f462