### PR TITLE
Update info alert text color

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -28,3 +28,8 @@
   margin-top: 1rem;
   font-size: 1.1rem;
 }
+
+/* Improve readability of info alerts */
+.stAlert-info {
+  color: #93c5fd !important;
+}

--- a/style.css
+++ b/style.css
@@ -122,7 +122,7 @@ p, div {
 .stAlert-info {
     background-color: rgba(59, 130, 246, 0.2) !important;
     border: 1px solid rgba(59, 130, 246, 0.4) !important;
-    color: #ffffff !important;
+    color: #93c5fd !important; /* Lighter blue for readability */
 }
 
 /* Section labels */


### PR DESCRIPTION
## Summary
- tweak the `.stAlert-info` rule in both `style.css` files
  - use a light blue text color for better readability

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687ed282b2348328a592a43ef8d86548