### PR TITLE
Fix footer button alignment

### DIFF
--- a/app.py
+++ b/app.py
@@ -4708,11 +4708,11 @@ def main():
 
     # Inside the centred column, create two equal columns for the buttons
     with col_terms:
-        if st.button("📄 Terms of Service", key="show_terms"):
+        if st.button("📄 Terms of Service", key="show_terms", use_container_width=True):
             st.session_state.display_terms = True
 
     with col_privacy:
-        if st.button("🔒 Privacy Policy", key="show_privacy"):
+        if st.button("🔒 Privacy Policy", key="show_privacy", use_container_width=True):
             st.session_state.display_privacy = True
 
     # Centered tagline and contact below buttons


### PR DESCRIPTION
## Summary
- ensure Terms of Service and Privacy Policy buttons fill their columns

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687ed2cd02588328b397ee8afe310166