### PR TITLE
Style browse files button

### DIFF
--- a/app.py
+++ b/app.py
@@ -1357,7 +1357,8 @@ def inject_custom_css():
         border-color: #000000 !important;
     }
 
-    [data-testid="stFileUploader"] * {
+    [data-testid="stFileUploader"] label span {
+        background-color: #000000 !important;
         color: #000000 !important;
     }
     


### PR DESCRIPTION
## Summary
- style the 'Browse files' span in the uploader to use a black background and black text

## Testing
- `pytest -q` *(fails: ImportError, requirements not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687ed325e3088328bc94b8f3cb10ad7a