### PR TITLE
Update info alert text color

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -28,3 +28,10 @@
   margin-top: 1rem;
   font-size: 1.1rem;
 }
+
+/* Improve readability of info alerts */
+.stAlert-info,
+.stAlert-info p,
+.stAlert-info span {
+  color: #93c5fd !important;
+}

--- a/style.css
+++ b/style.css
@@ -122,7 +122,13 @@ p, div {
 .stAlert-info {
     background-color: rgba(59, 130, 246, 0.2) !important;
     border: 1px solid rgba(59, 130, 246, 0.4) !important;
-    color: #ffffff !important;
+}
+
+/* Ensure info alert text is light blue for readability */
+.stAlert-info,
+.stAlert-info p,
+.stAlert-info span {
+    color: #93c5fd !important;
 }
 
 /* Section labels */


### PR DESCRIPTION
## Summary
- update `.stAlert-info` style rules in both CSS files
  - apply light blue text color for info alerts and their child text

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_687ed282b2348328a592a43ef8d86548