### PR TITLE
Update info alert text color

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -28,3 +28,9 @@
   margin-top: 1rem;
   font-size: 1.1rem;
 }
+
+/* Improve readability of info alerts */
+.stAlert-info,
+.stAlert-info * {
+  color: #dbeafe !important;
+}

--- a/style.css
+++ b/style.css
@@ -89,8 +89,9 @@ p, div {
     color: #ffffff !important;
 }
 
-.stAlert p,
-.stAlert span {
+/* Default alert text color */
+.stAlert:not(.stAlert-info) p,
+.stAlert:not(.stAlert-info) span {
     color: #ffffff !important;
 }
 
@@ -106,8 +107,8 @@ p, div {
     color: #ffffff !important;
 }
 
-.stAlert,
-.stAlert p {
+.stAlert:not(.stAlert-info),
+.stAlert:not(.stAlert-info) p {
     color: #ffffff !important;
 }
 
@@ -122,7 +123,12 @@ p, div {
 .stAlert-info {
     background-color: rgba(59, 130, 246, 0.2) !important;
     border: 1px solid rgba(59, 130, 246, 0.4) !important;
-    color: #ffffff !important;
+}
+
+/* Ensure info alert text is light blue for readability */
+.stAlert-info,
+.stAlert-info * {
+    color: #dbeafe !important;
 }
 
 /* Section labels */


### PR DESCRIPTION
## Summary
- refine default alert styles
- make info alert text lighter for better readability

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ed282b2348328a592a43ef8d86548